### PR TITLE
Fix HTML extraction bug

### DIFF
--- a/src/gmail-client.js
+++ b/src/gmail-client.js
@@ -243,18 +243,22 @@ export class GmailClient {
    * @returns {string} HTML content
    */
   extractHtmlContent(payload) {
+    if (payload.mimeType === 'text/html' && payload.body?.data) {
+      return Buffer.from(payload.body.data, 'base64').toString('utf-8');
+    }
+
     if (payload.parts) {
       for (const part of payload.parts) {
         if (part.mimeType === 'text/html' && part.body?.data) {
           return Buffer.from(part.body.data, 'base64').toString('utf-8');
         }
-        
+
         // Recursively search in nested parts
         const htmlContent = this.extractHtmlContent(part);
         if (htmlContent) return htmlContent;
       }
     }
-    
+
     return '';
   }
 


### PR DESCRIPTION
## Summary
- ensure GmailClient handles root-level HTML parts when parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68552d83d09c8321815c7751cabd3d36